### PR TITLE
Update to use base64 encoded secrets in workflow

### DIFF
--- a/.github/workflows/dev-workflow.yaml
+++ b/.github/workflows/dev-workflow.yaml
@@ -69,9 +69,9 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_ID  }}:latest
           build-args: |
-            FTP_PRIVATE_KEY=${{ secrets.FTP_PRIVATE_KEY }}
-            SSL_KEY=${{ secrets.SSL_KEY }}
-            SSL_TRUST=${{ secrets.SSL_TRUST }}
+            FTP_PRIVATE_KEY=${{ secrets.FTP_PRIVATE_KEY_BASE_64 }}
+            SSL_KEY=${{ secrets.SSL_KEY_BASE_64 }}
+            SSL_TRUST=${{ secrets.SSL_TRUST_BASE_64 }}
           
   terraform_apply:
     name: terraform apply 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ ARG FTP_PRIVATE_KEY
 ARG SSL_KEY
 ARG SSL_TRUST
 
-RUN echo $FTP_PRIVATE_KEY > /home/death_date/DeathDate-war/src/main/resources/deathDevTest.openssh
-RUN echo $SSL_KEY > /home/death_date/DeathDate-war/src/main/resources/keys.jks
-RUN echo $SSL_TRUST > /home/death_date/DeathDate-war/src/main/resources/trust.jks
+RUN echo $FTP_PRIVATE_KEY | base64 -d > /home/death_date/DeathDate-war/src/main/resources/deathDevTest.openssh
+RUN echo $SSL_KEY | base64 -d > /home/death_date/DeathDate-war/src/main/resources/keys.jks
+RUN echo $SSL_TRUST | base64 -d > /home/death_date/DeathDate-war/src/main/resources/trust.jks
 
 RUN chmod 640 /home/death_date/DeathDate-war/src/main/resources/deathDevTest.openssh /home/death_date/DeathDate-war/src/main/resources/keys.jks /home/death_date/DeathDate-war/src/main/resources/trust.jks
 


### PR DESCRIPTION
Secrets stored as GitHub Secrets can be passed as build args to a Docker build. However, they must not contain any newlines or other special characters. These changes use base64-encoded versions of three secrets and decode them in the Dockerfile, ensuring that the secrets are properly passed to the Docker build.